### PR TITLE
doc: コードリーディングしてわかったことをコメントに記載

### DIFF
--- a/src/enclave/enc_int32_ops.cpp
+++ b/src/enclave/enc_int32_ops.cpp
@@ -14,6 +14,7 @@
  * SGX_error, if there was an error during decryption
 */
 
+// enclaveの中で走る演算のコアロジック（の一例）
 int enc_int32_cmp(uint8_t* int1,
                   size_t int1_len,
                   uint8_t* int2,
@@ -45,7 +46,7 @@ int enc_int32_cmp(uint8_t* int1,
               ? 0
               : (src1_decrypted < src2_decrypted) ? -1 : 1;
 
-    memcpy(result, &cmp, res_len);
+    memcpy(result, &cmp, res_len);  // 比較演算の結果程度は暗号化しない模様... ええんか？
 
     memset_s(pSrc1_decrypted, INT32_LENGTH, 0, INT32_LENGTH);
     memset_s(pSrc2_decrypted, INT32_LENGTH, 0, INT32_LENGTH);
@@ -112,7 +113,7 @@ int enc_int32_add(uint8_t* int1,
     if (int2bytearray((int32_t)decint3_int, dec_int3_v, INT32_LENGTH))
         return MEMORY_COPY_ERROR;
 
-    resp = encrypt_bytes(dec_int3_v, INT32_LENGTH, int3, int3_len);
+    resp = encrypt_bytes(dec_int3_v, INT32_LENGTH, int3, int3_len);  // 加算の結果は暗号化
 
     memset_s(dec_int1_v, INT32_LENGTH, 0, INT32_LENGTH);
     memset_s(dec_int2_v, INT32_LENGTH, 0, INT32_LENGTH);

--- a/src/enclave/enclave.cpp
+++ b/src/enclave/enclave.cpp
@@ -12,6 +12,7 @@ void free_allocated_memory(void* pointer)
     }
 }
 
+// カラムを暗号化するためのマスターキー（enclaveの中で生成し、シーリングしてどこかに保存）
 /* Generate a master key
  @input: uint8_t sealed_key - pointer to sealed master key array
          size_t - length of the array (=
@@ -39,6 +40,7 @@ int generateKeyEnclave(uint8_t* sealed_key, size_t sealedkey_len)
     return resp;
 }
 
+// `int loadKey(int item)` 関数の中で、シーリングされたマスターキーの保存先が `DATA_FILENAME` なるファイルであることが示されている。
 /* Load the master key from sealed data
  *  @input: uint8_t sealed_key - pointer to a sealed data byte array
             size_t - length of the array (=

--- a/src/enclave/enclave.edl
+++ b/src/enclave/enclave.edl
@@ -13,6 +13,8 @@ enclave {
     trusted {
         public int generateKeyEnclave([out, size = sealedkey_len] uint8_t *sealed_key, size_t sealedkey_len);
         public int loadKeyEnclave ([in, size = len]  uint8_t *key, size_t len);
+
+        /* POSIX Thread から一回だけECALLされる */
         public int enclaveProcess ([user_check]void* inQueue);
     };
 };

--- a/src/untrusted/extensions/encdb--0.0.1.sql
+++ b/src/untrusted/extensions/encdb--0.0.1.sql
@@ -118,6 +118,7 @@ LANGUAGE C IMMUTABLE STRICT;
 --AS '$libdir/encdb'
 --LANGUAGE C IMMUTABLE STRICT;
 
+-- Client Proxy が、SQLに現れた通常の整数を勝手にこの型に変換する。
 CREATE TYPE enc_int4 (
     INPUT          = pg_enc_int4_in,
     OUTPUT         = pg_enc_int4_out,
@@ -287,6 +288,7 @@ CREATE AGGREGATE max_simple (enc_int4)
    finalfunc = pg_enc_int4_maxfinal
 );
 
+-- こいつが演算子のオーバーライド的なことをして、 enc_int4 同士の足し算を pg_enc_int4_add にdispatchさせてる。
 CREATE OPERATOR + (
   LEFTARG = enc_int4,
   RIGHTARG = enc_int4,

--- a/src/untrusted/interface/enc_int32.cpp
+++ b/src/untrusted/interface/enc_int32.cpp
@@ -57,6 +57,7 @@ int enc_int32_sum_bulk(size_t bulk_size, char* arg1, char* res)
             memcpy(int3_v, req->buffer + current_position, ENC_INT32_LENGTH);
             resp = req->resp;
             if (!ToBase64Fast(  // 演算結果の受け渡しはbase64 enc/dec してるっぽいが何でだろ？バイト列のままじゃいかんのか？
+                                // → SQLに現れる平文のデータをClient Proxyで暗号化してSQL書き換えるからだ。SQL中にバイト列は載せられぬ
                     (const BYTE*)int3_v, ENC_INT32_LENGTH, res, ENC_INT32_LENGTH_B64))
                 resp = BASE64DECODER_ERROR;
             spin_unlock(&req->is_done);  // spin-lock しているが、「そんなに大量の演算が並列で処理されることもないから無駄は少ない」という見積りなんだと思う

--- a/src/untrusted/interface/interface.cpp
+++ b/src/untrusted/interface/interface.cpp
@@ -38,7 +38,7 @@ int init() // こいつは呼ばれておらず、 initMultithreading() が使�
 void enclaveThread()
 {
     int resp = 0;
-    enclaveProcess(global_eid, &resp, inQueue);
+    enclaveProcess(global_eid, &resp, inQueue);  // ECALL
 }
 int initMultithreading()
 {

--- a/src/untrusted/interface/interface.cpp
+++ b/src/untrusted/interface/interface.cpp
@@ -17,7 +17,7 @@ int launch_enclave(sgx_launch_token_t* token, int* updated)
 {
     sgx_status_t ret = SGX_ERROR_UNEXPECTED;
 
-    ret = sgx_create_enclave(
+    ret = sgx_create_enclave(  // See: https://qiita.com/Cliffford/items/c6c0c696d4cc6d60d515#enclave%E3%81%AE%E8%B5%B7%E5%8B%95
         ENCLAVE_FILENAME, TRUE, token, updated, &global_eid, NULL);
     if (ret != SGX_SUCCESS)
         return ret;
@@ -25,7 +25,7 @@ int launch_enclave(sgx_launch_token_t* token, int* updated)
         return 0;
 }
 
-int init()
+int init() // こいつは呼ばれておらず、 initMultithreading() が使われている
 {
     sgx_launch_token_t token = { 0 };
     int updated = 0;
@@ -43,7 +43,7 @@ void enclaveThread()
 int initMultithreading()
 {
     sgx_launch_token_t token = { 0 };
-    int updated = 0;
+    int updated = 0;  // この後この変数は省みられてないし、起動トークンは勝手にupdateしてもらう使い方をしている。
     status = true;
     int ans = launch_enclave(&token, &updated);
 


### PR DESCRIPTION
## わかったことまとめ

- `exit-less mechanism` の仕組み
  - Enclave内で常に走るPOSIX Threadを立てて、そいつがジョブキューを監視 & deque。Enclave外からはenque。
  - 演算結果はジョブキューのデータ領域に書き戻す。Enclave外は投げたジョブの `is_done` フラグをspin-lockで監視
- エクステンションに処理が回ってきた初回に、上記ジョブキューなどを立ち上げる方法
  - グローバル変数で制御。もっとエクステンションの初期化関数とかいい場所ないんか？
    - → https://github.com/laysakura/stealthdb/blob/aa7b0bbe6074f339249d2e920d8bd7b2a0b49162/src/untrusted/extensions/encdb.c#L47 ここでもやってる。各演算子の処理でも呼んでるのは「念の為」・・・？
- PostgreSQL的な型・演算子の定義と、dispatch先の関数の繋ぎ込み
  - `src/untrusted/extensions/encdb--0.0.1.sql` ですべてやられてる
- カラム暗号化のためのマスターキーの生成 in Enclave・保存（シーリング）・ロード方法